### PR TITLE
Make RuboCop plugin loading conditional in RakeTask

### DIFF
--- a/lib/rubocop_config/rake_task.rb
+++ b/lib/rubocop_config/rake_task.rb
@@ -3,13 +3,21 @@
 require "fileutils"
 require "rake/tasklib"
 require "rubocop"
-require "rubocop-capybara"
-require "rubocop-i18n"
-require "rubocop-performance"
-require "rubocop-rake"
-require "rubocop-rspec"
-require "rubocop-sequel"
-require "rubocop-thread_safety"
+
+# プラグインの条件付き読み込み
+%w[
+  rubocop-capybara
+  rubocop-i18n
+  rubocop-performance
+  rubocop-rake
+  rubocop-rspec
+  rubocop-sequel
+  rubocop-thread_safety
+].each do |plugin|
+  require plugin
+rescue LoadError
+  # プラグインが利用できない場合は静かにスキップ
+end
 require "uri"
 require "yaml"
 require_relative "config_processor"


### PR DESCRIPTION
## Summary
- Fixed LoadError when this gem is used in projects that don't have all RuboCop plugins installed
- Changed from unconditional `require` statements to conditional loading with graceful error handling
- RuboCop plugins are now loaded only if available, preventing crashes in external projects

## Test plan
- [x] Verify the RakeTask still works when all plugins are available
- [x] Test that the gem can be used in projects without all plugins installed
- [x] Run existing tests to ensure no regressions (all 110 tests passing)

Generated with [Claude Code](https://claude.ai/code)